### PR TITLE
Corrige configuración de metallb esperando 60 segundos antes de configurarlo

### DIFF
--- a/ansible/roles/k3s-gateway/tasks/main.yml
+++ b/ansible/roles/k3s-gateway/tasks/main.yml
@@ -22,6 +22,12 @@
   changed_when: false
   become: false
 
+- name: Esperar 60 secs mientras el servicio metallb inicializa
+  ansible.builtin.command: sleep 60
+  register: metallb_sleepoutput
+  changed_when: metallb_sleepoutput.rc != 0
+  failed_when: metallb_sleepoutput.rc != 0
+
 - name: Copia manifiesto de IPAddressPool para metallb
   ansible.builtin.template:
     src: IPAddressPool.yml.j2


### PR DESCRIPTION
Cambios:
- Agrega tiempo de espera antes de configurar metallb para esperar a que la instalación termine por completo.