### PR TITLE
Organize metallb tasks on separate file

### DIFF
--- a/ansible/roles/k3s-gateway/tasks/main.yml
+++ b/ansible/roles/k3s-gateway/tasks/main.yml
@@ -1,56 +1,8 @@
 ---
 # tasks file for k3s-gateway
 
-- name: Agregar repositoro helm metallb
-  ansible.builtin.command: helm repo add metallb https://metallb.github.io/metallb
-  changed_when: false
-  become: false
-
-- name: Actualizar repositorios helm con metallb
-  ansible.builtin.command: helm repo update
-  changed_when: false
-  become: false
-
-- name: Agregar namespace metallb
-  ansible.builtin.shell: kubectl get ns {{ metallb_namespace }} || kubectl create namespace {{ metallb_namespace }}
-  changed_when: false
-
-- name: Instalar metallb
-  ansible.builtin.shell: |
-    helm ls -n {{ metallb_namespace }} | grep metallb || helm install metallb metallb/metallb \
-      --namespace {{ metallb_namespace }}
-  changed_when: false
-  become: false
-
-- name: Esperar 210 secs mientras el servicio metallb inicializa
-  ansible.builtin.command: sleep 210
-  register: metallb_sleepoutput
-  changed_when: metallb_sleepoutput.rc != 0
-  failed_when: metallb_sleepoutput.rc != 0
-
-- name: Copia manifiesto de IPAddressPool para metallb
-  ansible.builtin.template:
-    src: IPAddressPool.yml.j2
-    dest: /tmp/IPAddressPool.yml
-    owner: root
-    group: root
-    mode: '0640'
-
-- name: Instala recurso IPAddressPool para metallb
-  ansible.builtin.shell: kubectl apply -f /tmp/IPAddressPool.yml
-  changed_when: false
-
-- name: Copia manifiesto de L2Advertisement para metallb
-  ansible.builtin.template:
-    src: L2Advertisement.yml.j2
-    dest: /tmp/L2Advertisement.yml
-    owner: root
-    group: root
-    mode: '0640'
-
-- name: Instala recurso L2Advertisement para metallb
-  ansible.builtin.shell: kubectl apply -f /tmp/L2Advertisement.yml
-  changed_when: false
+- name: Incluir tareas de configuración de metallb
+  ansible.builtin.import_tasks: metallb.yml
 
 - name: Incluir tareas de configuración de ingress-nginx
   ansible.builtin.import_tasks: ingress-nginx.yml

--- a/ansible/roles/k3s-gateway/tasks/metallb.yml
+++ b/ansible/roles/k3s-gateway/tasks/metallb.yml
@@ -1,25 +1,29 @@
 ---
 # tasks file for k3s-gateway/metallb
 
+- name: Copia manifiesto de recurso namespace para metallb
+  ansible.builtin.template:
+    src: metallb-namespace.yml.j2
+    dest: /tmp/metallb-namespace.yml
+    owner: root
+    group: root
+    mode: '0640'
+  changed_when: false
+
+- name: Instala recurso namespace para metallb
+  ansible.builtin.shell: kubectl apply -f /tmp/metallb-namespace.yml
+  changed_when: false
+
 - name: Agregar repositoro helm metallb
-  ansible.builtin.command: helm repo add metallb https://metallb.github.io/metallb
-  changed_when: false
-  become: false
-
-- name: Actualizar repositorios helm con metallb
-  ansible.builtin.command: helm repo update
-  changed_when: false
-  become: false
-
-- name: Agregar namespace metallb
-  ansible.builtin.shell: kubectl get ns {{ metallb_namespace }} || kubectl create namespace {{ metallb_namespace }}
-  changed_when: false
+  kubernetes.core.helm_repository:
+    name: metallb
+    repo_url: https://metallb.github.io/metallb
 
 - name: Instalar metallb
-  ansible.builtin.shell: |
-    helm ls -n {{ metallb_namespace }} | grep metallb || helm install metallb metallb/metallb \
-      --namespace {{ metallb_namespace }}
-  changed_when: false
+  kubernetes.core.helm:
+    name: metallb
+    chart_ref: metallb/metallb
+    release_namespace: "{{ metallb_namespace }}"
   become: false
 
 - name: Esperar 210 secs mientras el servicio metallb inicializa

--- a/ansible/roles/k3s-gateway/tasks/metallb.yml
+++ b/ansible/roles/k3s-gateway/tasks/metallb.yml
@@ -1,0 +1,53 @@
+---
+# tasks file for k3s-gateway/metallb
+
+- name: Agregar repositoro helm metallb
+  ansible.builtin.command: helm repo add metallb https://metallb.github.io/metallb
+  changed_when: false
+  become: false
+
+- name: Actualizar repositorios helm con metallb
+  ansible.builtin.command: helm repo update
+  changed_when: false
+  become: false
+
+- name: Agregar namespace metallb
+  ansible.builtin.shell: kubectl get ns {{ metallb_namespace }} || kubectl create namespace {{ metallb_namespace }}
+  changed_when: false
+
+- name: Instalar metallb
+  ansible.builtin.shell: |
+    helm ls -n {{ metallb_namespace }} | grep metallb || helm install metallb metallb/metallb \
+      --namespace {{ metallb_namespace }}
+  changed_when: false
+  become: false
+
+- name: Esperar 210 secs mientras el servicio metallb inicializa
+  ansible.builtin.command: sleep 210
+  register: metallb_sleepoutput
+  changed_when: metallb_sleepoutput.rc != 0
+  failed_when: metallb_sleepoutput.rc != 0
+
+- name: Copia manifiesto de IPAddressPool para metallb
+  ansible.builtin.template:
+    src: IPAddressPool.yml.j2
+    dest: /tmp/IPAddressPool.yml
+    owner: root
+    group: root
+    mode: '0640'
+
+- name: Instala recurso IPAddressPool para metallb
+  ansible.builtin.shell: kubectl apply -f /tmp/IPAddressPool.yml
+  changed_when: false
+
+- name: Copia manifiesto de L2Advertisement para metallb
+  ansible.builtin.template:
+    src: L2Advertisement.yml.j2
+    dest: /tmp/L2Advertisement.yml
+    owner: root
+    group: root
+    mode: '0640'
+
+- name: Instala recurso L2Advertisement para metallb
+  ansible.builtin.shell: kubectl apply -f /tmp/L2Advertisement.yml
+  changed_when: false


### PR DESCRIPTION
Cambios:
- Se mueven tareas de metallb de main.yml a metall.yml
- Se cambian comandos shell por modulo helm