### PR TITLE
Update method to wait for metallb-controller deployment

### DIFF
--- a/ansible/roles/k3s-gateway/tasks/metallb.yml
+++ b/ansible/roles/k3s-gateway/tasks/metallb.yml
@@ -19,18 +19,22 @@
     name: metallb
     repo_url: https://metallb.github.io/metallb
 
-- name: Instalar metallb
+- name: Instalar helm chart de metallb
   kubernetes.core.helm:
     name: metallb
     chart_ref: metallb/metallb
     release_namespace: "{{ metallb_namespace }}"
   become: false
 
-- name: Esperar 210 secs mientras el servicio metallb inicializa
-  ansible.builtin.command: sleep 210
-  register: metallb_sleepoutput
-  changed_when: metallb_sleepoutput.rc != 0
-  failed_when: metallb_sleepoutput.rc != 0
+- name: Esperar hasta que el servicio metallb-controller inicialice
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: metallb-controller
+    namespace: metallb
+    wait: true
+    wait_sleep: 10
+    wait_timeout: 210
+  become: false
 
 - name: Copia manifiesto de IPAddressPool para metallb
   ansible.builtin.template:


### PR DESCRIPTION
Cambios:
- Elimina tarea de espera usando comando sleep
- Agrega tarea de espera de deployment usando módulo kubernetes.core.k8s.info

Referencias:
- https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_info_module.html