### PR TITLE
Agrega tareas para usar kubernetes.core.k8s_info para ver que levanten pods

### DIFF
--- a/ansible/roles/k3s-gateway/tasks/cert-manager.yml
+++ b/ansible/roles/k3s-gateway/tasks/cert-manager.yml
@@ -29,6 +29,16 @@
     state: present
   become: false
 
+- name: Esperar hasta que el servicio cert-manager inicialice
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: cert-manager
+    namespace: "{{ cert_manager_namespace }}"
+    wait: true
+    wait_sleep: 10
+    wait_timeout: 210
+  become: false
+
 - name: Copia manifiesto de recurso clusterissuer root ca para cert-manager
   ansible.builtin.template:
     src: cert-manager-root-ca.yml.j2

--- a/ansible/roles/k3s-gateway/tasks/external-dns.yml
+++ b/ansible/roles/k3s-gateway/tasks/external-dns.yml
@@ -56,3 +56,13 @@
       logLevel: info
     state: present
   become: false
+
+- name: Esperar hasta que el servicio external-dns inicialice
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: external-dns
+    namespace: "{{ external_dns_namespace }}"
+    wait: true
+    wait_sleep: 10
+    wait_timeout: 210
+  become: false

--- a/ansible/roles/k3s-gateway/tasks/ingress-nginx.yml
+++ b/ansible/roles/k3s-gateway/tasks/ingress-nginx.yml
@@ -32,3 +32,13 @@
       controller.minAvailable: "{{ ingress_nginx_min_available }}"
       defaultBackend.enabled: "{{ ingress_nginx_default_backend_enabled }}"
   become: false
+
+- name: Esperar hasta que el servicio ingress-nginx inicialice
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: ingress-ingress-nginx-controller
+    namespace: "{{ ingress_nginx_namespace }}"
+    wait: true
+    wait_sleep: 10
+    wait_timeout: 210
+  become: false


### PR DESCRIPTION
Cambios:
- Agrega tarea para revisar que levanten los pods de ingress-nginx
- Agrega tarea para revisar que levanten los pods de external-dns
- Agrega tarea para revisar que levanten los pods de cert-manager