### PR TITLE
Actualiza k3s-gateway con tareas para bajar el certificado raíz de cert-manager

### DIFF
--- a/ansible/roles/k3s-gateway/defaults/main.yml
+++ b/ansible/roles/k3s-gateway/defaults/main.yml
@@ -20,9 +20,13 @@ external_dns_namespace: "external-dns"
 bind_server_ip: "192.168.101.10"
 bind_zone_name: "hq.kronops.io"
 bind_tsig_keyname: "externaldns-key"
-bind_tsig_keysecret: "CHANGEME"
-bind_tsig_secretname: "external-dns-tsig"
+bind_tsig_keysecret: "CHANGEME" # pragma: allowlist secret
+bind_tsig_secretname: "external-dns-tsig" # pragma: allowlist secret
 
 # cert-manager settings
 cert_manager_namespace: "cert-manager"
 cert_manager_org_name: "kronops"
+ca_secret_name: "{{ cert_manager_org_name }}-root-ca-secret"
+ca_output_dir: /usr/local/share/ca-certificates/local
+ca_output_file: "{{ cert_manager_org_name }}-root-ca.crt"
+ca_custom_dir: ./inventory/.certs

--- a/ansible/roles/k3s-gateway/tasks/get-root-ca-certs.yml
+++ b/ansible/roles/k3s-gateway/tasks/get-root-ca-certs.yml
@@ -1,0 +1,41 @@
+---
+# tasks file for k3s-gateway/get-root-ca-certs
+
+- name: Asegurar que el directorio de salida para los certificados existe
+  ansible.builtin.file:
+    path: "{{ ca_output_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0750'
+
+- name: Obtener certificado raíz (tls.crt) desde secret de cert-manager
+  ansible.builtin.shell: |
+    kubectl get secret {{ ca_secret_name }} -n {{ cert_manager_namespace }} \
+      -o jsonpath="{.data['tls\.crt']}" | \
+      base64 -d > {{ ca_output_dir }}/{{ ca_output_file }}
+  args:
+    executable: /bin/bash
+  changed_when: true
+
+- name: Verificar que el certificado se ha escrito correctamente
+  ansible.builtin.stat:
+    path: "{{ ca_output_dir }}/{{ ca_output_file }}"
+  register: cert_stat
+
+- name: Mostrar listado de certificados
+  ansible.builtin.debug:
+    msg: "Certificado raíz exportado a {{ ca_output_dir }}/{{ ca_output_file }}"
+  when: cert_stat.stat.exists
+
+- name: Registrar CA como confiable en el sistema (update-ca-certificates)
+  ansible.builtin.command: update-ca-certificates
+  when: cert_stat.stat.exists
+  changed_when: true
+
+- name: Copiar certificado raíz a control node para distribución
+  ansible.builtin.fetch:
+    src: "{{ ca_output_dir }}/{{ ca_output_file }}"
+    dest: "{{ ca_custom_dir }}/{{ ca_output_file }}"
+    flat: true
+  when: cert_stat.stat.exists

--- a/ansible/roles/k3s-gateway/tasks/main.yml
+++ b/ansible/roles/k3s-gateway/tasks/main.yml
@@ -12,3 +12,6 @@
 
 - name: Incluir tareas de configuración de cert-manager
   ansible.builtin.import_tasks: cert-manager.yml
+
+- name: Incluir tareas de configuración de get-root-ca-certs
+  ansible.builtin.import_tasks: get-root-ca-certs.yml


### PR DESCRIPTION
Cambios:
- Agrega variables default para tareas que bajan certificado raíz
- Agrega tareas que bajan el certificado raíz al nodo maestro