### PR TITLE
Cambia metodo para validar que cluster ya esta arriba

### DIFF
--- a/ansible/roles/k3s-server/tasks/main.yml
+++ b/ansible/roles/k3s-server/tasks/main.yml
@@ -1,22 +1,8 @@
 ---
 # tasks file for k3s-server
 
-- name: Instalar servidor k3s
-  ansible.builtin.shell: curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ k3s_channel }} sh -s - --write-kubeconfig-mode 600 --disable traefik --disable servicelb
-  changed_when: false
-
-- name: Esperar 30 secs mientras el servidor inicializa
-  ansible.builtin.command: sleep 30
-  register: sleepoutput
-  changed_when: sleepoutput.rc != 0
-  failed_when: sleepoutput.rc != 0
-
-- name: Taint nodo maestro para no schedule
-  ansible.builtin.command: kubectl taint --overwrite node {{ inventory_hostname_short }} node-role.kubernetes.io/master=true:NoSchedule
-  register: taintoutput
-  changed_when: taintoutput.rc != 0
-  failed_when: taintoutput.rc != 0
-  when: k3s_taint_control_plane
+- name: Incluir tareas de despliegue de cluster k3s
+  ansible.builtin.import_tasks: server.yml
 
 - name: Incluir tareas de configuración de kubeconfig
   ansible.builtin.import_tasks: kubeconfig.yml

--- a/ansible/roles/k3s-server/tasks/server.yml
+++ b/ansible/roles/k3s-server/tasks/server.yml
@@ -5,11 +5,25 @@
   ansible.builtin.shell: curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ k3s_channel }} sh -s - --write-kubeconfig-mode 600 --disable traefik --disable servicelb
   changed_when: false
 
-- name: Esperar 30 secs mientras el servidor inicializa
-  ansible.builtin.command: sleep 30
-  register: sleepoutput
-  changed_when: sleepoutput.rc != 0
-  failed_when: sleepoutput.rc != 0
+- name: Esperar hasta que el servicio coredns inicialice
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: coredns
+    namespace: kube-system
+    wait: true
+    wait_sleep: 5
+    wait_timeout: 30
+  become: false
+
+- name: Esperar hasta que el servicio metrics-server inicialice
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: metrics-server
+    namespace: kube-system
+    wait: true
+    wait_sleep: 5
+    wait_timeout: 30
+  become: false
 
 - name: Taint nodo maestro para no schedule
   ansible.builtin.command: kubectl taint --overwrite node {{ inventory_hostname_short }} node-role.kubernetes.io/master=true:NoSchedule

--- a/ansible/roles/k3s-server/tasks/server.yml
+++ b/ansible/roles/k3s-server/tasks/server.yml
@@ -1,0 +1,19 @@
+---
+# tasks file for k3s-server
+
+- name: Instalar servidor k3s
+  ansible.builtin.shell: curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ k3s_channel }} sh -s - --write-kubeconfig-mode 600 --disable traefik --disable servicelb
+  changed_when: false
+
+- name: Esperar 30 secs mientras el servidor inicializa
+  ansible.builtin.command: sleep 30
+  register: sleepoutput
+  changed_when: sleepoutput.rc != 0
+  failed_when: sleepoutput.rc != 0
+
+- name: Taint nodo maestro para no schedule
+  ansible.builtin.command: kubectl taint --overwrite node {{ inventory_hostname_short }} node-role.kubernetes.io/master=true:NoSchedule
+  register: taintoutput
+  changed_when: taintoutput.rc != 0
+  failed_when: taintoutput.rc != 0
+  when: k3s_taint_control_plane


### PR DESCRIPTION
Cambios:
- Se quita tarea que usa comando del shell sleep para esperar a que levante
- Se agrega tarea para validar que el servicio kube-system/coredns ya esta arriba
- Se agrega tarea para validar que el servicio kube-system/metrics-server ya esta arriba